### PR TITLE
Modify EventHandler.zsc to make cash rewards instant deposit.

### DIFF
--- a/zscript/accensus/merchant/EventHandler.zsc
+++ b/zscript/accensus/merchant/EventHandler.zsc
@@ -371,8 +371,8 @@ class MerchantHandler : EventHandler
 			}
 			else
 			{
-				mob.DropNewItem('MercenaryBucksPickup');
-				amount -= random(1, 4);
+				amount = AceCore.GiveToPlayers('MercenaryBucks',(amount/random(2,5))); //Genericfiredemon: Code taken from line 263 of Bounty.zsc and modified for basic cash.
+				amount -= random(1, 25); //random range raised, due to the fact leaving it unchanged with the instant deposit code, it'd give the player quite a bit more money than it was originally set to drop.
 			}
 		}
 	}


### PR DESCRIPTION
Changes to lines 374-375 to change cash spawns into an instant deposit, and balances loop's logic accordingly.